### PR TITLE
Avoid leveraging vim recursion

### DIFF
--- a/plugin/symlink.vim
+++ b/plugin/symlink.vim
@@ -6,14 +6,17 @@ let g:symlink_loaded = 1
 let g:symlink_redraw = get(g:,'symlink_redraw', 1)
 
 function! s:on_buf_read(filepath)
-  if !filereadable(a:filepath)
-    return
-  endif
-
-  let l:resolved = resolve(a:filepath)
-  if l:resolved ==# a:filepath
-    return
-  endif
+  let l:resolved = a:filepath
+  while 1
+    let l:next = resolve(expand(l:resolved))
+    if !filereadable(l:next) || l:next ==# a:filepath
+      return
+    endif
+    if l:next ==# l:resolved
+      break
+    endif
+    let l:resolved = l:next
+  endwhile
 
   if exists(':Bwipeout') " vim-bbye
     Bwipeout


### PR DESCRIPTION
Leveraging Vim autocmd recursion and `a:filepath` sometimes caused issues (infinite recursion).

This PR implements an iterative resolve/expand algorithm. We still need to have `nested` so that the other autocommands trigger when we edit the final filepath (otherwise you would for example be missing syntax hightlighting).