### PR TITLE
ignore bbye error for convenience

### DIFF
--- a/plugin/symlink.vim
+++ b/plugin/symlink.vim
@@ -16,7 +16,7 @@ function! s:on_buf_read(filepath)
   endif
 
   if exists(':Bwipeout') " vim-bbye
-    Bwipeout
+    silent! Bwipeout
   else
     if &diff
       echoerr "symlink.vim: 'moll/vim-bbye' is required in order for this plugin to properly work in diff mode"


### PR DESCRIPTION
BUG: bbye error message on vim opening two symlinked files
`vim ~/.zshrc ~/.profile # both files are symlinks`
I think bbye panics when trying to wipe 'hidden' buffers that haven't been shown yet (the second symlinked file)
this pull request just prepends `silent!` to Bwipeout so that the error message doesn't show