### PR TITLE
autocmd: replace BufRead -> BufEnter

### DIFF
--- a/plugin/symlink.vim
+++ b/plugin/symlink.vim
@@ -35,5 +35,5 @@ endfunction
 
 augroup symlink_plugin
   autocmd!
-  autocmd BufRead * nested call s:on_buf_read(expand('<afile>'))
+  autocmd BufEnter * nested call s:on_buf_read(expand('<afile>'))
 augroup END


### PR DESCRIPTION
This PR replaces the `BufRead` autocmd with `BufEnter. Closes https://github.com/aymericbeaumet/vim-symlink/issues/14.
See my comments on that issue.

In addition to `BufEnter`, I also tried several other autocmd events:
- `BufWinEnter`
- `BufEnter`
- `BufNew`
- `BufAdd`
- `BufWinEnter`

All of these other attempts failed with various incorrect behavior or errors (some of which originated from other neovim plugins that I have installed).



### To install `vim-symlink` from my personal fork to test out this PR:

Install with [packer](https://github.com/wbthomason/packer.nvim):
```lua
use { 'jasha10/vim-symlink', branch = 'neovim0.9-autocmd-issue', requires = { 'moll/vim-bbye' } }
```

Install with [lazy.nvim](https://github.com/folke/lazy.nvim):

```lua
{ "jasha10/vim-symlink", branch = 'neovim0.9-autocmd-issue', dependencies = { "moll/vim-bbye" } }
```

Install with [vim-plug](https://github.com/junegunn/vim-plug):

```vim
Plug 'jasha10/vim-symlink', { 'branch': 'neovim0.9-autocmd-issue' }
Plug 'moll/vim-bbye' " optional dependency
```

# Details

Here are the things I tried:
<details>

```vim
  " ORIGINAL CODE:
  " autocmd BufRead * nested call s:on_buf_read(expand('<afile>'))
    " Error detected while processing BufReadPost Autocommands for "*":
    " Error executing lua callback: ...t_nvimvYmr7k/usr/share/nvim/runtime/lua/editorconfig.lua:210: Invalid buffer id: 1
    " stack traceback:
    "         [C]: in function 'nvim_buf_get_name'
    "         ...t_nvimvYmr7k/usr/share/nvim/runtime/lua/editorconfig.lua:210: in function 'config'
    "         ...vimvYmr7k/usr/share/nvim/runtime/plugin/editorconfig.lua:11: in function <...vimvYmr7k/usr/share/nvim/runtime/plugin/editorconfig.lu
    " a:4>

  " autocmd BufWinEnter * nested call s:on_buf_read(expand('<afile>'))
  " Works for first file. Subsequent :edit ~/my_symlink gave error:
    " Error detected while processing BufWinEnter Autocommands for "*"..function <SNR>44_on_buf_read[21]..BufReadPost Autocommands for "*":
    " Error executing lua callback: /tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:21: Error executing lua: /tmp/.mount_nvim4mcEfh/usr/sh
    " are/nvim/runtime/filetype.lua:22: BufWinEnter Autocommands for "*"..function <SNR>44_on_buf_read[21]..BufReadPost Autocommands for "*"..FileTyp
    " e Autocommands for "*"..function <SNR>62_filetype_changed[4]..remote#define#request, line 2: Vim(let):Error invoking '/home/homestar/.local/sha
    " re/nvim/lazy/semshi/rplugin/python3/semshi:command:Semshi' on channel 5 (python3-rplugin-host):
    " error caught in request handler '/home/homestar/.local/share/nvim/lazy/semshi/rplugin/python3/semshi:command:Semshi [['enable']]':
    " Traceback (most recent call last):
    "   File "/home/homestar/.local/share/nvim/lazy/semshi/rplugin/python3/semshi/plugin.py", line 126, in cmd_semshi
    "     func(self, *args[1:])
    "   File "/home/homestar/.local/share/nvim/lazy/semshi/rplugin/python3/semshi/plugin.py", line 32, in wrapper
    "     func(self, *args, **kwargs)
    "   File "/home/homestar/.local/share/nvim/lazy/semshi/rplugin/python3/semshi/plugin.py", line 144, in enable
    "     self._attach_listeners()
    "   File "/home/homestar/.local/share/nvim/lazy/semshi/rplugin/python3/semshi/plugin.py", line 248, in _attach_listeners
    "     self._vim.call('semshi#buffer_attach')
    "   File "/home/homestar/miniconda3/envs/neovim/lib/python3.11/site-packages/pynvim/api/nvim.py", line 299, in call
    "     return self.request('nvim_call_function', name, args, **kwargs)
    "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    "   File "/home/homestar/miniconda3/envs/neovim/lib/python3.11/site-packages/pynvim/api/nvim.py", line 182, in request
    "     res = self._session.request(name, *args, **kwargs)
    "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    "   File "/home/homestar/miniconda3/envs/neovim/lib/python3.11/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
    "     raise self.error_wrapper(err)
    " pynvim.api.common.NvimError: BufWinEnter Autocommands for "*"..function <SNR>44_on_buf_read[21]..BufReadPost Autocommands for "*"..FileType Aut
    " ocommands for "*"..function <SNR>62_filetype_changed[4]..remote#define#request[2]..semshi#buffer_attach[15]..SemshiBufEnter[1]..remote#define#r
    " equest, line 2: Vim(let):error caught while executing async callback:
    " stack traceback:
    "         [C]: in function 'nvim_cmd'
    "         /tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:22: in function </tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:
    " 21>
    "         [C]: in function 'nvim_buf_call'
    "         /tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:21: in function </tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:
    " 10>
    " stack traceback:
    "         [C]: in function 'nvim_buf_call'
    "         /tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:21: in function </tmp/.mount_nvim4mcEfh/usr/share/nvim/runtime/filetype.lua:
    " 10>
    " Error detected while processing BufWinEnter Autocommands for "*"..function <SNR>44_on_buf_read[21]..BufEnter Autocommands for "<buffer=5>"..fun
    " ction SemshiBufEnter[1]..remote#define#request:
    " line    2:
    " python3-rplugin-host: Async request caused an error:
    " BufWinEnter Autocommands for "*"..function <SNR>44_on_buf_read[21]..BufEnter Autocommands for "<buffer=5>"..function SemshiBufEnter[1]..remote#
    " define#request, line 2: Vim(sign):E158: Invalid buffer name: 4
    " python3-rplugin-host: Async request caused an error:
    " Invalid buffer id: 4

  " autocmd BufEnter * nested call s:on_buf_read(expand('<afile>'))
  " Works for first file. Subsequent :edit ~/my_symlink gave error:
    " python3-rplugin-host: Async request caused an error:
    " Vim(sign):E158: Invalid buffer name: 4
    " python3-rplugin-host: Async request caused an error:
    " Invalid buffer id: 4

  " autocmd BufNew * nested call s:on_buf_read(expand('<afile>'))
  " No error, but doesn't resolve symlink. Also messes with calling :edit ~/my_symlink,
  " which changes *all* windows pointing to previous buffer (instead of just the current window)

  " autocmd BufAdd * nested call s:on_buf_read(expand('<afile>'))
  " No error, but doesn't resolve symlink. Also messes with calling :edit ~/my_symlink,
  " which changes *all* windows pointing to previous buffer (instead of just the current window)

  autocmd BufEnter * nested call s:on_buf_read(expand('<afile>'))
  " Works!

  " autocmd BufWinEnter * nested call s:on_buf_read(expand('<afile>'))
  " Error:
    " Error detected while processing BufWinEnter Autocommands for "*":
    " E5108: Error executing lua ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: Invalid buffer id: 1
    " stack traceback:
    "         [C]: in function 'nvim_buf_get_option'
    "         ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: in function 'load_ft_func'
    "         ...cal/share/nvim/lazy/LuaSnip/lua/luasnip/loaders/util.lua:195: in function 'get_load_fts'
    "         ...share/nvim/lazy/LuaSnip/lua/luasnip/loaders/from_lua.lua:122: in function '_load_lazy_loaded'
    "         [string ":lua"]:1: in main chunk
    " E5108: Error executing lua ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: Invalid buffer id: 1
    " stack traceback:
    "         [C]: in function 'nvim_buf_get_option'
    "         ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: in function 'load_ft_func'
    "         ...cal/share/nvim/lazy/LuaSnip/lua/luasnip/loaders/util.lua:195: in function 'get_load_fts'
    "         .../nvim/lazy/LuaSnip/lua/luasnip/loaders/from_snipmate.lua:207: in function '_load_lazy_loaded'
    "         [string ":lua"]:1: in main chunk
    " E5108: Error executing lua ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: Invalid buffer id: 1
    " stack traceback:
    "         [C]: in function 'nvim_buf_get_option'
    "         ...m/lazy/LuaSnip/lua/luasnip/extras/filetype_functions.lua:41: in function 'load_ft_func'
    "         ...cal/share/nvim/lazy/LuaSnip/lua/luasnip/loaders/util.lua:195: in function 'get_load_fts'
    "         ...re/nvim/lazy/LuaSnip/lua/luasnip/loaders/from_vscode.lua:251: in function '_load_lazy_loaded'
    "         [string ":lua"]:1: in main chunk
```

<details/>