### PR TITLE
Workaround for "E13: File exists (add ! to override)" when writing a file that was opened from symlink

### DIFF
--- a/lua/symlink/init.lua
+++ b/lua/symlink/init.lua
@@ -50,6 +50,8 @@ local function resolve_symlink()
       vim.cmd('redraw')
     end
 
+    vim.cmd('edit')
+
     vim.api.nvim_exec_autocmds('User', { pattern = 'SymlinkResolve' })
   end)
 


### PR DESCRIPTION
Bug description:

As of neovim 0.12.2, using vim-symlink to edit a symlink and then writing with `:w` does not write successfully; the editor prompts the user to use `:w!` instead.

Proposed workaround:

Guessing that the buffer's state is somehow not set up competely, I tried to add a call to `:edit` after following the symlink, which seems to resolve the issue.
