### PR TITLE
fix: reopen resolved files through fresh buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test-vim:
 	cd test && $(VIM) -NEsu vimrc -o fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-horizontal.vader'
 	cd test && $(VIM) -NEsu vimrc -O fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-vertical.vader'
 	cd test && $(VIM) -NEsu vimrc -d fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-vertical.vader'
+	cd test && $(VIM) -NEsu vimrc -p fixture/foo.link fixture/bar.link -S symlink-tabs.vim
 	cd test && $(VIM) -NEsu vimrc                                      -c 'Vader! symlink-edge-cases.vader'
 	cd test && $(VIM) -NEsu vimrc                                      -c 'Vader! symlink-regressions.vader'
 
@@ -29,5 +30,6 @@ test-nvim:
 	cd test && $(NVIM) --headless -N -u vimrc -o fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-horizontal.vader'
 	cd test && $(NVIM) --headless -N -u vimrc -O fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-vertical.vader'
 	cd test && $(NVIM) --headless -N -u vimrc -d fixture/foo.link fixture/bar.link -c 'Vader! symlink-split-vertical.vader'
+	cd test && $(NVIM) --headless -N -u vimrc -p fixture/foo.link fixture/bar.link -S symlink-tabs.vim
 	cd test && $(NVIM) --headless -N -u vimrc                                      -c 'Vader! symlink-edge-cases.vader'
 	cd test && $(NVIM) --headless -N -u vimrc                                      -c 'Vader! symlink-regressions.vader'

--- a/doc/symlink.txt
+++ b/doc/symlink.txt
@@ -10,9 +10,9 @@ License: MIT
 Neovim in a cross-platform way. This means that when you edit a pathname that
 is a symlink, vim will instead open the file using the resolved target path.
 
-In Neovim (0.7+), a native Lua implementation is used for better performance.
-In Vim, an equivalent VimScript implementation is used. Both implementations
-share the same features and behavior.
+In Neovim, a native Lua implementation is used. In Vim, an equivalent
+VimScript implementation is used. Both implementations share the same features
+and behavior.
 
                             {1}: https://github.com/aymericbeaumet/vim-symlink
 

--- a/lua/symlink/init.lua
+++ b/lua/symlink/init.lua
@@ -1,14 +1,83 @@
 local M = {}
 
 local resolving = false
+local pending_reopens = {}
 
-local function resolve_symlink()
+local function buffer_exists(bufnr)
+  return vim.fn.bufexists(bufnr) == 1
+end
+
+local function delete_buffer(bufnr)
+  if not buffer_exists(bufnr) then
+    return
+  end
+
+  pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  if buffer_exists(bufnr) then
+    vim.cmd('silent! bwipeout ' .. bufnr)
+  end
+end
+
+local function goto_window(winid)
+  return vim.fn.win_gotoid(winid) == 1
+end
+
+local function restore_window(winid)
+  if winid ~= 0 then
+    pcall(vim.fn.win_gotoid, winid)
+  end
+end
+
+local function switch_windows_to_buffer(winids, target)
+  local current = vim.fn.win_getid()
+  for _, winid in ipairs(winids) do
+    if goto_window(winid) then
+      vim.cmd('keepalt buffer ' .. target)
+    end
+  end
+  restore_window(current)
+end
+
+local function reopen_nvim_buffer(bufnr, resolved)
+  if not buffer_exists(bufnr) then
+    return
+  end
+
+  local winids = vim.fn.win_findbuf(bufnr)
+  if #winids == 0 then
+    return
+  end
+
+  local current = vim.fn.win_getid()
+  if goto_window(winids[1]) and vim.api.nvim_get_current_buf() == bufnr then
+    vim.cmd('keepalt file ' .. vim.fn.fnameescape(vim.fn.tempname()))
+  end
+
+  vim.cmd('badd ' .. vim.fn.fnameescape(resolved))
+  local target = vim.fn.bufnr(resolved)
+  switch_windows_to_buffer(winids, target)
+
+  if buffer_exists(bufnr) and bufnr ~= vim.api.nvim_get_current_buf() then
+    delete_buffer(bufnr)
+  end
+  restore_window(current)
+end
+
+function M.reopen_pending_nvim_buffers()
+  local pending = pending_reopens
+  pending_reopens = {}
+  for _, item in ipairs(pending) do
+    reopen_nvim_buffer(item.bufnr, item.resolved)
+  end
+end
+
+function M.resolve_symlink()
   if vim.g.symlink_enabled == 0 or resolving then
     return
   end
 
   local bufnr = vim.api.nvim_get_current_buf()
-  local buftype = vim.bo[bufnr].buftype
+  local buftype = vim.fn.getbufvar(bufnr, '&buftype')
   if buftype ~= '' then
     return
   end
@@ -33,40 +102,52 @@ local function resolve_symlink()
   local ok, err = pcall(function()
     local existing = vim.fn.bufnr(resolved)
     if existing ~= -1 and existing ~= bufnr then
-      local winid = vim.api.nvim_get_current_win()
-      vim.api.nvim_set_current_buf(existing)
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-      vim.api.nvim_set_current_win(winid)
+      switch_windows_to_buffer(vim.fn.win_findbuf(bufnr), existing)
+      delete_buffer(bufnr)
     else
-      vim.api.nvim_buf_set_name(bufnr, resolved)
-      local old = vim.fn.bufnr(fname)
-      if old ~= -1 and old ~= bufnr then
-        pcall(vim.api.nvim_buf_delete, old, { force = true })
+      vim.cmd('keepalt file ' .. vim.fn.fnameescape(resolved))
+      if vim.v.vim_did_enter == 0 and vim.fn.argc() > 1 then
+        table.insert(pending_reopens, { bufnr = bufnr, resolved = resolved })
+      else
+        reopen_nvim_buffer(bufnr, resolved)
       end
-      vim.cmd('edit')
     end
 
     if vim.g.symlink_redraw == 1 then
       vim.cmd('redraw')
     end
 
-    vim.api.nvim_exec_autocmds('User', { pattern = 'SymlinkResolve' })
+    vim.cmd('silent! doautocmd <nomodeline> User SymlinkResolve')
   end)
 
   resolving = false
 
   if not ok then
-    vim.notify('vim-symlink: ' .. tostring(err), vim.log.levels.WARN)
+    local message = 'vim-symlink: ' .. tostring(err)
+    if vim.notify then
+      local level = vim.log and vim.log.levels and vim.log.levels.WARN or nil
+      vim.notify(message, level)
+    else
+      vim.api.nvim_err_writeln(message)
+    end
   end
 end
 
 function M.setup()
-  vim.api.nvim_create_augroup('symlink_plugin', { clear = true })
-  vim.api.nvim_create_autocmd('BufReadPost', {
-    group = 'symlink_plugin',
-    pattern = '*',
-    callback = resolve_symlink,
-  })
+  if vim.g.symlink_redraw == nil then
+    vim.g.symlink_redraw = 1
+  end
+  if vim.g.symlink_enabled == nil then
+    vim.g.symlink_enabled = 1
+  end
+
+  vim.cmd([[
+    augroup symlink_plugin
+      autocmd!
+      autocmd BufReadPost * lua require('symlink').resolve_symlink()
+      autocmd VimEnter * lua require('symlink').reopen_pending_nvim_buffers()
+    augroup END
+  ]])
 end
 
 return M

--- a/plugin/symlink.nvim.vim
+++ b/plugin/symlink.nvim.vim
@@ -1,0 +1,10 @@
+if !has('nvim') || exists('g:symlink_loaded')
+  finish
+endif
+let g:symlink_loaded = 1
+
+let g:symlink_redraw = get(g:, 'symlink_redraw', 1)
+let g:symlink_enabled = get(g:, 'symlink_enabled', 1)
+let g:symlink_implementation = 'lua'
+
+lua require('symlink').setup()

--- a/plugin/symlink.vim
+++ b/plugin/symlink.vim
@@ -1,4 +1,4 @@
-if exists('g:symlink_loaded')
+if has('nvim') || exists('g:symlink_loaded')
   finish
 endif
 let g:symlink_loaded = 1
@@ -6,15 +6,57 @@ let g:symlink_loaded = 1
 let g:symlink_redraw = get(g:, 'symlink_redraw', 1)
 let g:symlink_enabled = get(g:, 'symlink_enabled', 1)
 
-if has('nvim-0.7')
-  let g:symlink_implementation = 'lua'
-  lua require('symlink').setup()
-  finish
-endif
-
 let g:symlink_implementation = 'vim'
 
 let s:resolving = 0
+let s:pending_reopens = []
+
+function! s:switch_windows_to_buffer(winids, target) abort
+  let l:current = win_getid()
+  for l:winid in a:winids
+    if win_gotoid(l:winid)
+      execute 'keepalt buffer ' . a:target
+    endif
+  endfor
+  if l:current != 0
+    call win_gotoid(l:current)
+  endif
+endfunction
+
+function! s:reopen_vim_buffer(bufnr, resolved) abort
+  if !bufexists(a:bufnr)
+    return
+  endif
+
+  let l:winids = win_findbuf(a:bufnr)
+  if empty(l:winids)
+    return
+  endif
+
+  let l:current = win_getid()
+  if win_gotoid(l:winids[0]) && bufnr('%') == a:bufnr
+    execute 'keepalt file ' . fnameescape(tempname())
+  endif
+
+  execute 'badd ' . fnameescape(a:resolved)
+  let l:target = bufnr(a:resolved)
+  call s:switch_windows_to_buffer(l:winids, l:target)
+
+  if bufexists(a:bufnr) && a:bufnr != bufnr('%')
+    execute 'silent! bwipeout ' . a:bufnr
+  endif
+  if l:current != 0
+    call win_gotoid(l:current)
+  endif
+endfunction
+
+function! s:reopen_pending_vim_buffers() abort
+  let l:pending = s:pending_reopens
+  let s:pending_reopens = []
+  for l:item in l:pending
+    call s:reopen_vim_buffer(l:item.bufnr, l:item.resolved)
+  endfor
+endfunction
 
 function! s:resolve_symlink() abort
   if !g:symlink_enabled || s:resolving
@@ -41,17 +83,15 @@ function! s:resolve_symlink() abort
   try
     let l:existing = bufnr(l:resolved)
     if l:existing != -1 && l:existing != l:bufnr
-      let l:winid = win_getid()
-      execute 'buffer ' . l:existing
+      call s:switch_windows_to_buffer(win_findbuf(l:bufnr), l:existing)
       execute 'silent! bwipeout ' . l:bufnr
-      call win_gotoid(l:winid)
     else
       execute 'keepalt file ' . fnameescape(l:resolved)
-      let l:old = bufnr(l:fname)
-      if l:old != -1 && l:old != bufnr('%')
-        execute 'silent! bwipeout ' . l:old
+      if !v:vim_did_enter && argc() > 1
+        call add(s:pending_reopens, {'bufnr': l:bufnr, 'resolved': l:resolved})
+      else
+        call s:reopen_vim_buffer(l:bufnr, l:resolved)
       endif
-      edit
     endif
 
     if g:symlink_redraw
@@ -67,4 +107,5 @@ endfunction
 augroup symlink_plugin
   autocmd!
   autocmd BufReadPost * call s:resolve_symlink()
+  autocmd VimEnter * call s:reopen_pending_vim_buffers()
 augroup END

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ resolved target path.
 - Allow to create new files in symlinked directories
 - Make [vim-fugitive](https://github.com/tpope/vim-fugitive) behave properly
   with linked files
-- Native Lua implementation for Neovim (0.7+) with VimScript fallback for Vim
+- Native Lua implementation for Neovim with VimScript implementation for Vim
 - No dependencies required
 - Runtime enable/disable via `g:symlink_enabled`
 - `User SymlinkResolve` event for custom hooks

--- a/test/symlink-regressions.vader
+++ b/test/symlink-regressions.vader
@@ -25,6 +25,27 @@ Then (no E13 and the resolved file received the write):
   Assert g:e13_errmsg !~# 'E37', 'expected no E37, got: ' . g:e13_errmsg
   AssertEqual ['initial', 'appended'], g:e13_target_content
 
+Execute (#22: :w on a file under a resolved symlinked directory succeeds without E13):
+  let g:e13_dir = tempname()
+  let g:e13_real_dir = g:e13_dir . '.real'
+  let g:e13_link_dir = g:e13_dir . '.link'
+  let g:e13_file = g:e13_real_dir . '/init.vim'
+  call mkdir(g:e13_real_dir, 'p')
+  call writefile(['set number'], g:e13_file)
+  call system('ln -s ' . shellescape(g:e13_real_dir) . ' ' . shellescape(g:e13_link_dir))
+  execute 'edit! ' . fnameescape(g:e13_link_dir . '/init.vim')
+  call append(line('$'), 'set relativenumber')
+  let v:errmsg = ''
+  silent! write
+  let g:e13_dir_errmsg = v:errmsg
+  let g:e13_dir_content = readfile(g:e13_file)
+  call delete(g:e13_link_dir)
+  call delete(g:e13_real_dir, 'rf')
+Then (no E13 and the resolved directory target received the write):
+  Assert g:e13_dir_errmsg !~# 'E13', 'expected no E13, got: ' . g:e13_dir_errmsg
+  Assert g:e13_dir_errmsg !~# 'E37', 'expected no E37, got: ' . g:e13_dir_errmsg
+  AssertEqual ['set number', 'set relativenumber'], g:e13_dir_content
+
 " ------- Issue #17 -------
 " :vimgrep across files inside a symlinked directory must not emit
 " `E937: Attempt to delete a buffer that is in use`.
@@ -37,6 +58,33 @@ Execute (#17: :vimgrep on a symlinked directory does not raise E937):
   redir END
 Then (no E937 from buffer churn):
   Assert g:vg_messages !~# 'E937', 'expected no E937, got: ' . g:vg_messages
+
+" ------- Issue #10 -------
+" Users must be able to opt out for selected symlinks without disabling the
+" plugin permanently.
+
+Execute (#10: autocmds can skip selected symlinks and keep following others):
+  let g:symlink_enabled = 1
+  augroup test_selective_symlink_disable
+    autocmd!
+    autocmd BufReadPre */bar.link let g:symlink_enabled = 0
+    autocmd BufReadPost */bar.link let g:symlink_enabled = 1
+  augroup END
+  edit! fixture/bar.link
+  let g:selective_disabled_path = expand('%:.')
+  edit! fixture/foo.link
+  let g:selective_enabled_path = expand('%:.')
+  edit! fixture/baz
+  silent! bwipeout fixture/bar.link
+  silent! bwipeout fixture/foo
+  silent! bwipeout fixture/foo.link
+  augroup test_selective_symlink_disable
+    autocmd!
+  augroup END
+  let g:symlink_enabled = 1
+Then (only the selected symlink remained unresolved):
+  Assert g:selective_disabled_path =~# 'fixture/bar\.link$', 'expected skipped symlink path, got: ' . g:selective_disabled_path
+  AssertEqual 'fixture/foo', g:selective_enabled_path
 
 " ------- Issue #14, PR #16 -------
 " Other BufReadPost autocmds (e.g. neovim's editorconfig) must see a valid
@@ -97,6 +145,31 @@ Execute (#6: chained and repeated symlink edits do not trigger E218):
 Then (no nesting-too-deep error):
   Assert g:nest_errmsg !~# 'E218', 'expected no E218, got: ' . g:nest_errmsg
 
+Execute (#6: help files under a symlinked runtime load without autocmd recursion):
+  let g:help_root = tempname()
+  let g:help_real = g:help_root . '.real'
+  let g:help_link = g:help_root . '.link'
+  call mkdir(g:help_real . '/doc', 'p')
+  call writefile(['*issue6-help-tag*', 'Issue 6 help file'], g:help_real . '/doc/issue6.txt')
+  execute 'helptags ' . fnameescape(g:help_real . '/doc')
+  call system('ln -s ' . shellescape(g:help_real) . ' ' . shellescape(g:help_link))
+  let g:help_rtp_save = &runtimepath
+  let &runtimepath = g:help_link . ',' . &runtimepath
+  let v:errmsg = ''
+  silent! help issue6-help-tag
+  let g:help_errmsg = v:errmsg
+  let g:help_buftype = &buftype
+  let g:help_line = getline(1)
+  bwipeout!
+  let &runtimepath = g:help_rtp_save
+  call delete(g:help_link)
+  call delete(g:help_real, 'rf')
+Then (help opened and no nesting-too-deep error leaked):
+  Assert g:help_errmsg !~# 'E218', 'expected no E218, got: ' . g:help_errmsg
+  Assert g:help_errmsg !~# 'E171', 'expected no E171, got: ' . g:help_errmsg
+  AssertEqual 'help', g:help_buftype
+  AssertEqual '*issue6-help-tag*', g:help_line
+
 " ------- Issue #5 -------
 " After symlink resolution, BufWinEnter must fire with the resolved name so
 " that features like mkview / loadview attach state to the resolved file.
@@ -114,3 +187,36 @@ Execute (#5: BufWinEnter after resolve sees the resolved path):
 Then (BufWinEnter observed the resolved path, not the symlink):
   Assert g:bwe_seen !~# 'foo\.link$', 'BufWinEnter still saw the symlink path: ' . g:bwe_seen
   Assert g:bwe_seen =~# 'fixture/foo$', 'expected resolved path, got: ' . g:bwe_seen
+
+Execute (#5: mkview/loadview restores cursor after resolving a symlink):
+  let g:view_target = tempname()
+  let g:view_link = tempname() . '.link'
+  let g:view_dir = tempname()
+  call mkdir(g:view_dir, 'p')
+  call writefile(['one', 'two', 'three', 'four'], g:view_target)
+  call system('ln -s ' . shellescape(g:view_target) . ' ' . shellescape(g:view_link))
+  let g:viewdir_save = &viewdir
+  let g:viewoptions_save = &viewoptions
+  let &viewdir = g:view_dir
+  set viewoptions=cursor
+  augroup test_loadview_actual
+    autocmd!
+    autocmd BufWinLeave * silent! mkview!
+    autocmd BufWinEnter * silent! loadview
+  augroup END
+  execute 'edit! ' . fnameescape(g:view_link)
+  call cursor(3, 1)
+  edit! fixture/bar
+  execute 'edit! ' . fnameescape(g:view_link)
+  let g:view_restored_line = line('.')
+  augroup test_loadview_actual
+    autocmd!
+  augroup END
+  bwipeout!
+  let &viewdir = g:viewdir_save
+  let &viewoptions = g:viewoptions_save
+  call delete(g:view_link)
+  call delete(g:view_target)
+  call delete(g:view_dir, 'rf')
+Then (the saved cursor position was restored through the resolved path):
+  AssertEqual 3, g:view_restored_line

--- a/test/symlink-tabs.vim
+++ b/test/symlink-tabs.vim
@@ -1,0 +1,22 @@
+" Issue #2: tab startup should keep one resolved file per tab, like split and
+" diff startup keep one resolved file per window.
+execute 'cd ' . fnameescape(expand('<sfile>:p:h'))
+
+let v:errors = []
+
+call assert_equal(2, tabpagenr('$'), 'tab count')
+tabnext 1
+call assert_equal('fixture/foo', expand('%:.'), 'first tab path')
+call assert_equal(['foo'], getline(1, '$'), 'first tab content')
+tabnext 2
+call assert_equal('fixture/bar', expand('%:.'), 'second tab path')
+call assert_equal(['bar'], getline(1, '$'), 'second tab content')
+
+if !empty(v:errors)
+  for s:error in v:errors
+    echomsg s:error
+  endfor
+  cquit
+endif
+
+qall!

--- a/test/symlink.vader
+++ b/test/symlink.vader
@@ -6,7 +6,7 @@ Before:
 Execute (check implementation loaded):
   Assert exists('g:symlink_loaded'), 'g:symlink_loaded should be set'
   Assert exists('g:symlink_implementation'), 'g:symlink_implementation should be set'
-  if has('nvim-0.7')
+  if has('nvim')
     AssertEqual 'lua', g:symlink_implementation
   else
     AssertEqual 'vim', g:symlink_implementation


### PR DESCRIPTION
## Summary

- reopen resolved paths through fresh buffers so older Vim and Neovim releases retain the correct file identity and `:write` no longer raises `E13`
- preserve all windows and startup tabs while switching to the resolved target, including Neovim 0.6.1 compatibility
- expand regression coverage for writes, tab startup, selective disabling, help recursion, and view restoration

## Test plan

- `uvx --python 3.11 --with setuptools\<81 --from vim-vint==0.3.21 vint plugin`
- `make test-vim` (Vim 9.1)
- `make test-nvim` (Neovim 0.12.3)
- `make test-nvim NVIM=/tmp/.../nvim-osx64/bin/nvim` (Neovim 0.6.1)
- `make test-vim` in Ubuntu 22.04 (Vim 8.2.3995)