### PR TITLE
test: cover legacy Vim and Neovim versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,34 @@ jobs:
 
       - name: test-nvim
         run: make test-nvim
+
+  compatibility:
+    name: compatibility (${{ matrix.editor }} ${{ matrix.version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - editor: Vim
+            version: v8.2.3995
+            neovim: false
+            target: test-vim
+          - editor: Neovim
+            version: v0.6.1
+            neovim: true
+            target: test-nvim
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: install ${{ matrix.editor }} ${{ matrix.version }}
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: ${{ matrix.neovim }}
+          version: ${{ matrix.version }}
+
+      - name: test ${{ matrix.editor }} ${{ matrix.version }}
+        run: make ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- add Ubuntu compatibility jobs pinned to Vim `v8.2.3995` and Neovim `v0.6.1`, the versions reported in issue #22
- run the complete editor-specific test suite on each legacy version while retaining the existing latest-version Ubuntu/macOS matrix

## Test plan

- `docker run --rm --mount type=bind,src=$PWD,dst=/repo,readonly rhysd/actionlint:latest -color /repo/.github/workflows/ci.yml`
- full `make test-vim` suite on Ubuntu 22.04 / Vim 8.2.3995
- full `make test-nvim` suite on Neovim 0.6.1